### PR TITLE
support arguments for throttled methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## v1.0.1
+
+- BUGFIX: support arguments for throttled methods
+
 ## v1.0.0
 
 - initial release

--- a/lib/limiter/mixin.rb
+++ b/lib/limiter/mixin.rb
@@ -6,9 +6,9 @@ module Limiter
       queue = RateQueue.new(rate, interval: interval)
 
       mixin = Module.new do
-        define_method(method) do
+        define_method(method) do |*args|
           queue.shift
-          super()
+          super(*args)
         end
       end
 

--- a/lib/limiter/version.rb
+++ b/lib/limiter/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Limiter
-  VERSION = '1.0.0'
+  VERSION = '1.0.1'
 end

--- a/test/limiter/mixin_test.rb
+++ b/test/limiter/mixin_test.rb
@@ -22,8 +22,8 @@ module Limiter
         @ticks = 0
       end
 
-      def tick
-        @ticks += 1
+      def tick(count = 1)
+        @ticks += count
       end
     end
 
@@ -46,6 +46,11 @@ module Limiter
       end
 
       assert_equal COUNT, @object.ticks
+    end
+
+    def test_arguments_are_passed
+      @object.tick 123
+      assert_equal 123, @object.ticks
     end
   end
 end


### PR DESCRIPTION
fixes #1 

the mixin did not support methods with arguments
we were explicitly calling `super()` - which of course will not work

the issue is, that the usual approach of simply calling `super` without explicit args results in...
```
implicit argument passing of super from method defined by define_method() is not supported. Specify all arguments explicitly. (RuntimeError).
```

we work around this using `*args` instead
