### PR TITLE
fix gem name and bundler usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## v1.0.2
+
+- DOCFIX: fix name of gem in README
+- BUGFIX: add ruby-limiter.rb so that it works better with bundler
+
 ## v1.0.1
 
 - BUGFIX: support arguments for throttled methods

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This gem implements a simple mechanism to throttle or rate-limit operations in R
 Add this line to your application's Gemfile:
 
 ```ruby
-gem 'limiter'
+gem 'ruby-limiter'
 ```
 
 And then execute:
@@ -16,7 +16,7 @@ And then execute:
 
 Or install it yourself as:
 
-    $ gem install limiter
+    $ gem install ruby-limiter
 
 ## Usage
 

--- a/lib/limiter/version.rb
+++ b/lib/limiter/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Limiter
-  VERSION = '1.0.1'
+  VERSION = '1.0.2'
 end

--- a/lib/ruby-limiter.rb
+++ b/lib/ruby-limiter.rb
@@ -1,0 +1,1 @@
+require 'limiter'

--- a/limiter.gemspec
+++ b/limiter.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = %w(lib)
 
-  spec.add_development_dependency 'bundler', '~> 1.15'
+  spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rubocop', '~> 0.56'


### PR DESCRIPTION
fix #3 

* update the README so that it correctly documents `ruby-limiter` (rather than just `limiter`)
* add `lib/ruby-limiter.rb` so that bundler can find it
