### PR TITLE
Update README.md for 'Advanced Usage'

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ the `interval` parameter is optional (and defaults to 1 minute).
 class Widget
   def initialize
     # create a rate-limited queue which allows 10000 operations per hour
-    @queue = RateQueue.new(10000, interval: 3600)
+    @queue = Limiter::RateQueue.new(10000, interval: 3600)
   end
 
   def tick


### PR DESCRIPTION
### Description

While working on provider NS1 API rate limit, I just found out that if I just try to call `RateQueue` with `require 'limiter'`, it give me `NameError Exception`. 

1. It works fine with `Limiter::RateQueue`

2. Adding `include Limiter` works as well.
```
class Widget
  include Limiter
  def initialize
    # create a rate-limited queue which allows 10000 operations per hour
    @queue = RateQueue.new(10000, interval: 3600)
  end

  def tick
    # this operation will block until less than 10000 shift calls have been made within the last hour
    @queue.shift
    # do something
  end
end
```

But I might be wrong, so feel free to approve or not.
