### PR TITLE
improved sleep testing

### DIFF
--- a/lib/limiter/clock.rb
+++ b/lib/limiter/clock.rb
@@ -8,23 +8,13 @@ module Limiter
     include Singleton
 
     extend SingleForwardable
-    def_single_delegators :instance, :skip, :time
+    def_single_delegators :instance, :sleep, :time
 
-    def initialize
-      @offset = 0
-    end
-
-    def skip(interval)
-      @offset += interval
+    def sleep(interval)
+      Kernel.sleep(interval)
     end
 
     def time
-      now + @offset
-    end
-
-    private
-
-    def now
       Process.clock_gettime(Process::CLOCK_MONOTONIC)
     end
   end

--- a/lib/limiter/rate_queue.rb
+++ b/lib/limiter/rate_queue.rb
@@ -21,7 +21,7 @@ module Limiter
 
         sleep_until(time + @interval)
 
-        @ring[@head] = Clock.time
+        @ring[@head] = clock.time
         @head = (@head + 1) % @size
       end
 
@@ -31,9 +31,13 @@ module Limiter
     private
 
     def sleep_until(time)
-      interval = time - Clock.time
+      interval = time - clock.time
       return unless interval.positive?
-      sleep(interval)
+      clock.sleep(interval)
+    end
+
+    def clock
+      Clock
     end
   end
 end

--- a/limiter.gemspec
+++ b/limiter.gemspec
@@ -29,6 +29,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'minitest', '~> 5.0'
+  spec.add_development_dependency 'mocha', '~> 1.11'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rubocop', '~> 0.56'
 end

--- a/test/limiter/clock_test.rb
+++ b/test/limiter/clock_test.rb
@@ -12,10 +12,5 @@ module Limiter
     def test_clock_is_advancing
       assert Clock.time > @start_time
     end
-
-    def test_skips_interval
-      Clock.skip(300)
-      assert Clock.time >= (@start_time + 300)
-    end
   end
 end

--- a/test/limiter/mixin_test.rb
+++ b/test/limiter/mixin_test.rb
@@ -4,7 +4,6 @@ require 'test_helper'
 
 module Limiter
   class MixinTest < Minitest::Test
-    include FakeSleep
     include AssertElapsed
 
     COUNT = 50
@@ -29,6 +28,7 @@ module Limiter
 
     def setup
       super
+      RateQueue.any_instance.stubs(:clock).returns(FakeClock)
       @object = MixinTestClass.new
     end
 

--- a/test/limiter/rate_queue_test.rb
+++ b/test/limiter/rate_queue_test.rb
@@ -4,7 +4,6 @@ require 'test_helper'
 
 module Limiter
   class RateQueueTest < Minitest::Test
-    include FakeSleep
     include AssertElapsed
 
     COUNT = 50
@@ -14,6 +13,7 @@ module Limiter
     def setup
       super
       @queue = RateQueue.new(RATE, interval: INTERVAL)
+      @queue.stubs(:clock).returns(FakeClock)
     end
 
     def test_shift_is_rate_limited


### PR DESCRIPTION
instead of including the mock sleep operation in the clock implementation, reduce it to a basic sleep and time wrapper

add a testing-specific implementation which is injected during tests via a stub
