### PR TITLE
Update Rake

### DIFF
--- a/limiter.gemspec
+++ b/limiter.gemspec
@@ -30,6 +30,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'mocha', '~> 1.11'
-  spec.add_development_dependency 'rake', '~> 10.0'
+  spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'rubocop', '~> 0.56'
 end


### PR DESCRIPTION
This fixes the following warning when using Rake with Ruby 2.7:

```
.../gems/2.7.0/gems/rake-10.5.0/lib/rake/application.rb:381: warning: deprecated Object#=~ is called on Proc; it always returns nil
```