### PR TITLE
Fix Ruby 2.7 deprecation warnings when using keyword arguments

### DIFF
--- a/lib/limiter/mixin.rb
+++ b/lib/limiter/mixin.rb
@@ -6,9 +6,16 @@ module Limiter
       queue = RateQueue.new(rate, interval: interval)
 
       mixin = Module.new do
-        define_method(method) do |*args|
-          queue.shift
-          super(*args)
+        if RUBY_VERSION < "2.7"
+          define_method(method) do |*args|
+            queue.shift
+            super(*args)
+          end
+        else
+          define_method(method) do |*positional_args, **keyword_args|
+            queue.shift
+            super(*positional_args, **keyword_args)
+          end
         end
       end
 

--- a/test/limiter/mixin_test.rb
+++ b/test/limiter/mixin_test.rb
@@ -14,6 +14,7 @@ module Limiter
       extend Limiter::Mixin
 
       limit_method :tick, rate: RATE, interval: INTERVAL
+      limit_method :tick_with_kwargs, rate: RATE, interval: INTERVAL
 
       attr_reader :ticks
 
@@ -22,6 +23,10 @@ module Limiter
       end
 
       def tick(count = 1)
+        @ticks += count
+      end
+
+      def tick_with_kwargs(count: 1)
         @ticks += count
       end
     end
@@ -48,8 +53,13 @@ module Limiter
       assert_equal COUNT, @object.ticks
     end
 
-    def test_arguments_are_passed
+    def test_positional_arguments
       @object.tick 123
+      assert_equal 123, @object.ticks
+    end
+
+    def test_keyword_arguments
+      @object.tick_with_kwargs(count: 123)
       assert_equal 123, @object.ticks
     end
   end


### PR DESCRIPTION
At the moment, Ruby 2.7 issues the following deprecation warning if a
limited method uses keyword arguments:

```
limiter/lib/limiter/mixin.rb:19: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
```

This commit fixes it by explicitly passing keyword arguments to the
limited method with `**keyword_args`.

This change is backwards compatible and it works with positional
arguments, keyword arguments and also mixed arguments.
