### PR TITLE
Add block support to rate queue

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,10 @@ class Widget
 
   # limit the rate we can call tick to 5 times per second
   # when the rate has been exceeded, a call to tick will block until the rate limit would not be exceeded
-  limit_method :tick, rate: 5, interval: 1
+  # and the provided block will be executed
+  limit_method(:tick, rate: 5, interval: 1) do
+    puts 'Limit reached'
+  end
 
   ...
 end
@@ -55,13 +58,16 @@ end
 ### Advanced Usage
 
 In cases where the mixin is not appropriate the `RateQueue` class can be used directly. As in the mixin examples above,
-the `interval` parameter is optional (and defaults to 1 minute).
+the `interval` parameter is optional (and defaults to 1 minute). It is also possible
+to provide the block to `RateQueue`, which will be executed on each limit hit (useful for metrics).
 
 ``` ruby
 class Widget
   def initialize
     # create a rate-limited queue which allows 10000 operations per hour
-    @queue = Limiter::RateQueue.new(10000, interval: 3600)
+    @queue = Limiter::RateQueue.new(10000, interval: 3600) do
+      puts "Hit the limit, waiting"
+    end
   end
 
   def tick

--- a/lib/limiter/mixin.rb
+++ b/lib/limiter/mixin.rb
@@ -6,16 +6,9 @@ module Limiter
       queue = RateQueue.new(rate, interval: interval)
 
       mixin = Module.new do
-        if RUBY_VERSION < "2.7"
-          define_method(method) do |*args|
-            queue.shift
-            super(*args)
-          end
-        else
-          define_method(method) do |*args, **kwargs|
-            queue.shift
-            super(*args, **kwargs)
-          end
+        define_method(method) do |*args, **options, &blk|
+          queue.shift
+          options.empty? ? super(*args, &blk) : super(*args, **options, &blk)
         end
       end
 

--- a/lib/limiter/mixin.rb
+++ b/lib/limiter/mixin.rb
@@ -2,8 +2,8 @@
 
 module Limiter
   module Mixin
-    def limit_method(method, rate:, interval: 60)
-      queue = RateQueue.new(rate, interval: interval)
+    def limit_method(method, rate:, interval: 60, &b)
+      queue = RateQueue.new(rate, interval: interval, &b)
 
       mixin = Module.new do
         define_method(method) do |*args, **options, &blk|

--- a/lib/limiter/rate_queue.rb
+++ b/lib/limiter/rate_queue.rb
@@ -4,13 +4,14 @@ module Limiter
   class RateQueue
     EPOCH = 0.0
 
-    def initialize(size, interval: 60)
+    def initialize(size, interval: 60, &blk)
       @size = size
       @interval = interval
 
       @ring = Array.new(size, EPOCH)
       @head = 0
       @mutex = Mutex.new
+      @blk = blk
     end
 
     def shift
@@ -33,6 +34,7 @@ module Limiter
     def sleep_until(time)
       interval = time - clock.time
       return unless interval.positive?
+      @blk.call if @blk
       clock.sleep(interval)
     end
 

--- a/limiter.gemspec
+++ b/limiter.gemspec
@@ -13,6 +13,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'Simple Ruby rate limiting mechanism.'
   spec.homepage      = 'https://github.com/Shopify/limiter'
   spec.license       = 'MIT'
+  spec.required_ruby_version = Gem::Requirement.new(">= 2.6.0")
 
   if spec.respond_to?(:metadata)
     spec.metadata['allowed_push_host'] = "https://rubygems.org"

--- a/test/limiter/mixin_test.rb
+++ b/test/limiter/mixin_test.rb
@@ -70,5 +70,13 @@ module Limiter
       @object.tock(count: 321)
       assert_equal 321, @object.ticks
     end
+
+    def test_block_was_called_on_rate_limit
+      @block_hit = false
+      MixinTestClass.limit_method(:tick, rate: RATE, interval: INTERVAL) { @block_hit = true }
+      @object.tick
+      @object.tick
+      assert @block_hit
+    end
   end
 end

--- a/test/limiter/rate_queue_test.rb
+++ b/test/limiter/rate_queue_test.rb
@@ -35,5 +35,14 @@ module Limiter
         threads.each(&:join)
       end
     end
+
+    def test_block_was_called_on_rate_limit
+      @block_hit = false
+      @queue = RateQueue.new(RATE, interval: INTERVAL) { @block_hit = true }
+      @queue.stubs(:clock).returns(FakeClock)
+      @queue.shift
+      @queue.shift
+      assert @block_hit
+    end
   end
 end


### PR DESCRIPTION
Thank you for great gem!

* Add blocks support for `RateQueue` class, which allow to use this gem with custom metrics.
* Fix Ruby 2.7 warnings

Also:
Close #16 