### PR TITLE
feat: Simple load balanced rate control

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,27 @@ class Widget
 end
 ```
 
+#### Load balancing
+
+By default all calls to the `limit_method` will be bursted, e.g. as quick as possible, until the rate is exceeded.
+Then we wait for the remainder of the interval to continue. To even out the burst, an optional `balanced` parameter can be
+provided to enable interleaving between the method calls, e.g: `interleave = interval / size`.
+
+``` ruby
+  ...
+  limit_method :tick, rate: 60, balanced: true
+  ...
+```
+
+For example: with an interval of 60 seconds and a rate of 60:
+
+`balanced: false`
+: As quickly as possible we call the method 60 times, then we wait for the remainder of the time.
+
+`balanced: true`
+: We interleave each call with 1 second so we call this method every second.
+
+
 ### Advanced Usage
 
 In cases where the mixin is not appropriate the `RateQueue` class can be used directly. As in the mixin examples above,

--- a/lib/limiter/mixin.rb
+++ b/lib/limiter/mixin.rb
@@ -2,8 +2,8 @@
 
 module Limiter
   module Mixin
-    def limit_method(method, rate:, interval: 60, &b)
-      queue = RateQueue.new(rate, interval: interval, &b)
+    def limit_method(method, rate:, interval: 60, balanced: false, &b)
+      queue = RateQueue.new(rate, interval: interval, balanced: balanced, &b)
 
       mixin = Module.new do
         define_method(method) do |*args, **options, &blk|

--- a/test/limiter/rate_queue_test.rb
+++ b/test/limiter/rate_queue_test.rb
@@ -44,5 +44,27 @@ module Limiter
       @queue.shift
       assert @block_hit
     end
+
+    def test_shift_is_unbalanced_by_default
+      actual = @queue.instance_variable_get(:@ring)
+      actual.size.times.with_index do |idx|
+        assert_in_delta(actual[idx], 0.0)
+      end
+    end
+
+    def test_shift_is_balanced
+      subject = RateQueue.new(5, interval: 5, balanced: true)
+      expected = [
+        Clock.time - 5,
+        Clock.time - 4,
+        Clock.time - 3,
+        Clock.time - 2,
+        Clock.time - 1,
+      ]
+      actual = subject.instance_variable_get(:@ring)
+      actual.size.times.with_index do |idx|
+        assert_in_delta(actual[idx], expected[idx])
+      end
+    end
   end
 end


### PR DESCRIPTION
By introducing the option `balanced: true` we interleave the initial ring w/ the interval divided by size so all calls will have some air between each call e.g. a simple load balancing.

---

By default all calls to the `limit_method` will be bursted, e.g. as quick as possible, until the rate is exceeded.
Then we wait for the remainder of the interval to continue. To even out the burst, an optional `balanced` parameter can be
provided to enable interleaving between the method calls, e.g: `interleave = interval / size`.

``` ruby
  ...
  limit_method :tick, rate: 60, balanced: true
  ...
```

For example: with an interval of 60 seconds and a rate of 60:

`balanced: false` As quickly as possible we call the method 60 times, then we wait for the remainder of the time.

`balanced: true` We interleave each call with 1 second so we call this method every second.

---

Also fixed in this PR:

- chore(package): Use latest version of rubocop
- use ruby version 2.4 and up in travis and rubocop 
- chore(package): Add rubocop-minitest and rubocop-rake as suggested
- fix rubocop warnings

Considerations before merging this PR:

- Use `interleaved` instead of `balanced` as an option name
- Make the interleave configurable: e.g. instead of `true/false` provide
  an `float/integer` (which also favours renaming to `interleave`)
- ditch this PR because when this is an issue your rate/interval is wrong.