### PR TITLE
explicit tests for keyword arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## v2.0.1
+
+- eliminate kwarg warning in ruby 2.7 (while still supporting 2.6)
+
 ## v2.0.0
 
 - end support for ruby 2.3/2.4/2.5

--- a/Rakefile
+++ b/Rakefile
@@ -7,6 +7,7 @@ Rake::TestTask.new(:test) do |t|
   t.libs << "test"
   t.libs << "lib"
   t.test_files = FileList["test/**/*_test.rb"]
+  t.warning = true
 end
 
 task default: :test

--- a/lib/limiter/mixin.rb
+++ b/lib/limiter/mixin.rb
@@ -6,9 +6,16 @@ module Limiter
       queue = RateQueue.new(rate, interval: interval)
 
       mixin = Module.new do
-        define_method(method) do |*args|
-          queue.shift
-          super(*args)
+        if RUBY_VERSION < "2.7"
+          define_method(method) do |*args|
+            queue.shift
+            super(*args)
+          end
+        else
+          define_method(method) do |*args, **kwargs|
+            queue.shift
+            super(*args, **kwargs)
+          end
         end
       end
 

--- a/lib/limiter/version.rb
+++ b/lib/limiter/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Limiter
-  VERSION = '2.0.0'
+  VERSION = '2.0.1'
 end

--- a/limiter.gemspec
+++ b/limiter.gemspec
@@ -29,6 +29,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'minitest', '~> 5.0'
+  spec.add_development_dependency 'minitest-focus', '~> 1.3'
   spec.add_development_dependency 'mocha', '~> 1.11'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rubocop', '~> 0.56'

--- a/test/limiter/mixin_test.rb
+++ b/test/limiter/mixin_test.rb
@@ -14,6 +14,7 @@ module Limiter
       extend Limiter::Mixin
 
       limit_method :tick, rate: RATE, interval: INTERVAL
+      limit_method :tock, rate: RATE, interval: INTERVAL
 
       attr_reader :ticks
 
@@ -22,6 +23,10 @@ module Limiter
       end
 
       def tick(count = 1)
+        @ticks += count
+      end
+
+      def tock(count: 1)
         @ticks += count
       end
     end
@@ -51,6 +56,19 @@ module Limiter
     def test_arguments_are_passed
       @object.tick 123
       assert_equal 123, @object.ticks
+    end
+
+    def test_default_keyword_arguments_are_passed
+      COUNT.times do
+        @object.tock
+      end
+
+      assert_equal COUNT, @object.ticks
+    end
+
+    def test_keyword_arguments_are_passed
+      @object.tock(count: 321)
+      assert_equal 321, @object.ticks
     end
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -4,6 +4,7 @@ $LOAD_PATH.unshift File.expand_path('../lib', __dir__)
 require 'limiter'
 
 require 'minitest/autorun'
+require 'minitest/focus'
 require 'mocha/minitest'
 
 module Limiter


### PR DESCRIPTION
having deprecated ruby < 2.6 in #20 ...

this PR adds tests for keyword arguments (based on #16)

thanks @mrhead for doing the work before I got to it